### PR TITLE
Adding support for parsing plain text nodes that contain XML content

### DIFF
--- a/Source/src/main/java/com/wolfram/alpha/impl/WAPlainTextImpl.java
+++ b/Source/src/main/java/com/wolfram/alpha/impl/WAPlainTextImpl.java
@@ -5,14 +5,23 @@
 package com.wolfram.alpha.impl;
 
 import java.io.Serializable;
+import java.io.StringWriter;
 
 import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import com.wolfram.alpha.WAException;
 import com.wolfram.alpha.WAPlainText;
 import com.wolfram.alpha.visitor.Visitable;
 import com.wolfram.alpha.visitor.Visitor;
+
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
 
 
 public class WAPlainTextImpl implements WAPlainText, Visitable, Serializable {
@@ -24,7 +33,21 @@ public class WAPlainTextImpl implements WAPlainText, Visitable, Serializable {
     
     WAPlainTextImpl(Element thisElement) throws WAException {
         NodeList children = thisElement.getChildNodes();
-        text = children.getLength() > 0 ? children.item(0).getNodeValue() : "";
+        text = children.getLength() > 0 ? transformNodeToString(children.item(0)) : "";
+    }
+
+    private String transformNodeToString(Node node) throws WAException {
+        StringWriter writer = new StringWriter();
+
+        try {
+            Transformer transformer = TransformerFactory.newInstance().newTransformer();
+            transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+            transformer.transform(new DOMSource(node), new StreamResult(writer));
+        } catch (TransformerException ex) {
+            throw new WAException(ex);
+        }
+
+        return writer.toString();
     }
 
     


### PR DESCRIPTION
This change allows plain text nodes to be parsed when the content is composed of additional XML tags. For example:

```
<plaintext>
    <parent>
    <child>abc</child>
    </parent>
</plaintext>
```

This is needed, for example, when parsing semantic results.
